### PR TITLE
Check whatever panels is valid

### DIFF
--- a/lua/spropprotection/cl_init.lua
+++ b/lua/spropprotection/cl_init.lua
@@ -116,10 +116,11 @@ function SPropProtection.ClientPanel(Panel)
 end
 
 function SPropProtection.SpawnMenuOpen()
-	if SPropProtection.AdminCPanel then
+	if IsValid(SPropProtection.AdminCPanel) then
 		SPropProtection.AdminPanel(SPropProtection.AdminCPanel)
 	end
-	if SPropProtection.ClientCPanel then
+	
+	if IsValid(SPropProtection.ClientCPanel) then
 		SPropProtection.ClientPanel(SPropProtection.ClientCPanel)
 	end
 end


### PR DESCRIPTION
Fixes lua error after spawnmenu_reload
[ERROR] addons/simple prop protection/lua/spropprotection/cl_init.lua:89: attempt to call method 'ClearControls' (a nil value)
1. ClientPanel - addons/simple prop protection/lua/spropprotection/cl_init.lua:89
   1. fn - addons/simple prop protection/lua/spropprotection/cl_init.lua:123
   2. Call - addons/ulib/lua/ulib/shared/hook.lua:179
      1. Call - gamemodes/sandbox/gamemode/spawnmenu/spawnmenu.lua:224
      2. unknown - gamemodes/base/gamemode/cl_spawnmenu.lua:56
      3. unknown - lua/includes/modules/concommand.lua:54

How to reproduce:
Open spawn menu
Go to admin/client tab of SPP
Type spawnmenu_reload in the console
You are unable to open spawn menu because of error
